### PR TITLE
fix(crawler): improve account and browser lifecycle

### DIFF
--- a/app/crawler-service/src/index.ts
+++ b/app/crawler-service/src/index.ts
@@ -77,11 +77,11 @@ async function main() {
     })
 
     worker.on('completed', (job) => {
-        log.info(`Job ${job.id} completed`)
+        log.info(`Job ${job.id} completed`, { trace_id: job.id})
     })
 
     worker.on('failed', (job, err) => {
-        log.error(`Job ${job?.id} failed: ${err.message}`)
+        log.error(`Job ${job?.id} failed: ${err.message}`, { trace_id: job?.id})
     })
 
     worker.on('error', (err) => {

--- a/app/crawler-service/src/workers/crawler.ts
+++ b/app/crawler-service/src/workers/crawler.ts
@@ -159,7 +159,7 @@ export async function processCrawlerJob(
                 let cookie_string = ''
                 
                 if (config.auth === 'cookie') {
-                    currentAccount = await accountPoolService.getAccount(platform, config.auth_account)
+                    currentAccount = await accountPoolService.getAccount(platform, config.auth_account, task_id)
                     if (currentAccount) {
                         const cookies = parseNetscapeCookieToPuppeteerCookie(currentAccount.cookie_string)
                         cookie_string = cookies.map((coo) => `${coo.name}=${coo.value}`).join('; ')
@@ -210,13 +210,14 @@ export async function processCrawlerJob(
                 
             } catch (error) {
                 jobLog.error(`Error crawling ${website}: ${error}`)
-                let is_account_error = isRateLimitOrAuthError(error)
+                // let is_account_error = isRateLimitOrAuthError(error)
 
-                if (currentAccount && is_account_error) {
-                    await accountPoolService.releaseAccount(currentAccount.id)
-                    await accountPoolService.reportAccountFailure(currentAccount.id, 30)
-                    jobLog.warn(`Reported failure for account ${currentAccount.name} (id: ${currentAccount.id})`)
-                }
+                // if (currentAccount && is_account_error) {
+                //     await accountPoolService.releaseAccount(currentAccount.id)
+                //     await accountPoolService.reportAccountFailure(currentAccount.id, 30)
+                //     jobLog.warn(`Reported failure for account ${currentAccount.name} (id: ${currentAccount.id})`)
+                // }
+                await accountPoolService.releaseAccount(currentAccount.id)
             }
         }
 

--- a/app/crawler-service/src/workers/crawler.ts
+++ b/app/crawler-service/src/workers/crawler.ts
@@ -21,35 +21,31 @@ import { accountPoolService } from '@idol-bbq-utils/account-pool'
 const executingTasks = new Set<string>()
 
 export class BrowserPool {
-    private browsers: Browser[] = []
-    private tmpDirs: tmp.DirResult[] = []
+    private browsers: Array<{
+        browser: Browser
+        tmpDir: tmp.DirResult
+        pagesCreated: number
+        inUsePages: number
+        relaunching?: Promise<void>
+    }> = []
+    private pageOwner = new WeakMap<Page, (typeof this.browsers)[number]>()
     private currentIndex = 0
     private maxBrowsers: number
+    private maxPagesPerBrowser: number
     private log?: Logger
 
     constructor(maxBrowsers: number = 1, log?: Logger) {
         this.maxBrowsers = maxBrowsers
+        this.maxPagesPerBrowser = parseInt(process.env.BROWSER_MAX_PAGES_PER_INSTANCE || '200')
         this.log = log
     }
 
     async init(): Promise<void> {
         this.log?.info(`Initializing browser pool with ${this.maxBrowsers} browsers...`)
         for (let i = 0; i < this.maxBrowsers; i++) {
-            const tmpDir = tmp.dirSync({
-                prefix: `puppeteer-${i}-`,
-                unsafeCleanup: true,
-            })
-            this.tmpDirs.push(tmpDir)
-            this.log?.info(`Browser ${i + 1} userDataDir: ${tmpDir.name}`)
-
-            const browser = await puppeteer.launch({
-                headless: true,
-                args: [process.env.NO_SANDBOX ? '--no-sandbox' : '', '--disable-dev-shm-usage'].filter(Boolean),
-                channel: 'chrome',
-                userDataDir: tmpDir.name,
-            })
-            this.browsers.push(browser)
-            this.log?.info(`Browser ${i + 1} launched`)
+            const browserEntry = await this.launchBrowser(i)
+            this.browsers.push(browserEntry)
+            this.log?.info(`Browser ${i + 1} launched (max pages before recycle: ${this.maxPagesPerBrowser})`)
         }
     }
 
@@ -57,22 +53,150 @@ export class BrowserPool {
         if (this.browsers.length === 0) {
             throw new Error('Browser pool not initialized')
         }
-        const browser = this.browsers[this.currentIndex]!
+
+        const browserIndex = this.currentIndex
+        const browserEntry = this.browsers[browserIndex]!
         this.currentIndex = (this.currentIndex + 1) % this.browsers.length
-        return await browser.newPage()
+
+        await this.ensureBrowserReady(browserEntry)
+        const activeBrowserEntry = this.browsers[browserIndex]!
+
+        const page = await activeBrowserEntry.browser.newPage()
+        activeBrowserEntry.pagesCreated += 1
+        activeBrowserEntry.inUsePages += 1
+        this.pageOwner.set(page, activeBrowserEntry)
+        page.once('close', () => {
+            const owner = this.pageOwner.get(page)
+            if (!owner) {
+                return
+            }
+            owner.inUsePages = Math.max(0, owner.inUsePages - 1)
+            this.pageOwner.delete(page)
+            void this.maybeRecycleBrowser(owner)
+        })
+        return page
+    }
+
+    async releasePage(page: Page): Promise<void> {
+        if (!page.isClosed()) {
+            try {
+                await page.close()
+            } catch (error) {
+                this.log?.warn(`Failed to close page cleanly: ${error}`)
+            }
+        }
     }
 
     async close(): Promise<void> {
         this.log?.info('Closing browser pool...')
-        await Promise.all(this.browsers.map((b) => b.close()))
-        this.tmpDirs.forEach((tmpDir) => {
-            try {
-                tmpDir.removeCallback()
-            } catch (error) {
-                this.log?.warn(`Failed to cleanup tmpDir: ${error}`)
-            }
-        })
+        await Promise.all(this.browsers.map((entry, idx) => this.destroyBrowser(entry, idx)))
         this.log?.info('Browser pool closed')
+    }
+
+    private async launchBrowser(index: number) {
+        const tmpDir = tmp.dirSync({
+            prefix: `puppeteer-${index}-`,
+            unsafeCleanup: true,
+        })
+        this.log?.info(`Browser ${index + 1} userDataDir: ${tmpDir.name}`)
+
+        const browser = await puppeteer.launch({
+            headless: true,
+            args: [process.env.NO_SANDBOX ? '--no-sandbox' : '', '--disable-dev-shm-usage'].filter(Boolean),
+            channel: 'chrome',
+            userDataDir: tmpDir.name,
+        })
+
+        const browserEntry = {
+            browser,
+            tmpDir,
+            pagesCreated: 0,
+            inUsePages: 0,
+        }
+
+        browser.on('disconnected', () => {
+            this.log?.warn(`Browser ${index + 1} disconnected unexpectedly`)
+        })
+
+        return browserEntry
+    }
+
+    private async ensureBrowserReady(entry: (typeof this.browsers)[number]): Promise<void> {
+        if (entry.relaunching) {
+            await entry.relaunching
+            return
+        }
+
+        if (entry.browser.connected) {
+            return
+        }
+
+        entry.relaunching = (async () => {
+            const index = this.browsers.indexOf(entry)
+            if (index === -1) {
+                return
+            }
+            this.log?.warn(`Browser ${index + 1} is disconnected, relaunching...`)
+            await this.destroyBrowser(entry, index)
+            const relaunched = await this.launchBrowser(index)
+            this.browsers[index] = relaunched
+            this.log?.info(`Browser ${index + 1} relaunched`)
+        })()
+
+        try {
+            await entry.relaunching
+        } finally {
+            entry.relaunching = undefined
+        }
+    }
+
+    private async maybeRecycleBrowser(entry: (typeof this.browsers)[number]): Promise<void> {
+        if (entry.pagesCreated < this.maxPagesPerBrowser || entry.inUsePages > 0) {
+            return
+        }
+        if (entry.relaunching) {
+            return
+        }
+
+        entry.relaunching = (async () => {
+            const index = this.browsers.indexOf(entry)
+            if (index === -1) {
+                return
+            }
+            this.log?.info(`Recycling browser ${index + 1} after ${entry.pagesCreated} pages`)
+            await this.destroyBrowser(entry, index)
+            const relaunched = await this.launchBrowser(index)
+            this.browsers[index] = relaunched
+            this.log?.info(`Browser ${index + 1} recycled`)
+        })()
+
+        try {
+            await entry.relaunching
+        } finally {
+            entry.relaunching = undefined
+        }
+    }
+
+    private async destroyBrowser(entry: (typeof this.browsers)[number], index: number): Promise<void> {
+        const browserProcess = entry.browser.process()
+        try {
+            await entry.browser.close()
+        } catch (error) {
+            this.log?.warn(`Failed to close browser ${index + 1} cleanly: ${error}`)
+        } finally {
+            if (browserProcess && !browserProcess.killed) {
+                try {
+                    browserProcess.kill('SIGKILL')
+                } catch (error) {
+                    this.log?.warn(`Failed to kill browser ${index + 1} process: ${error}`)
+                }
+            }
+        }
+        try {
+            entry.tmpDir.removeCallback()
+        } catch (error) {
+            this.log?.warn(`Failed to cleanup tmpDir for browser ${index + 1}: ${error}`)
+        }
     }
 }
 
@@ -255,7 +379,7 @@ export async function processCrawlerJob(
         }
     } finally {
         if (page) {
-            await page.close()
+            await browserPool.releasePage(page)
         }
         executingTasks.delete(executionId)
         jobLog.info(`Task execution completed: ${executionId} (pool size: ${executingTasks.size})`)

--- a/app/crawler-service/src/workers/crawler.ts
+++ b/app/crawler-service/src/workers/crawler.ts
@@ -341,7 +341,9 @@ export async function processCrawlerJob(
                 //     await accountPoolService.reportAccountFailure(currentAccount.id, 30)
                 //     jobLog.warn(`Reported failure for account ${currentAccount.name} (id: ${currentAccount.id})`)
                 // }
-                await accountPoolService.releaseAccount(currentAccount.id)
+                if (currentAccount) {
+                    await accountPoolService.releaseAccount(currentAccount.id)
+                }
             }
         }
 

--- a/app/scheduler-service/src/workers/sender.ts
+++ b/app/scheduler-service/src/workers/sender.ts
@@ -460,11 +460,11 @@ export function startSenderWorker(queueManager: QueueManager, concurrency: numbe
     })
 
     worker.on('completed', (job) => {
-        log.info(`Job ${job.id} completed`)
+        log.info(`Job ${job.id} completed`, { trace_id: job.id})
     })
 
     worker.on('failed', (job, err) => {
-        log.error(`Job ${job?.id} failed: ${err.message}`)
+        log.error(`Job ${job?.id} failed: ${err.message}`, { trace_id: job?.id })
     })
 
     worker.on('error', (err) => {

--- a/core/account-pool/src/index.ts
+++ b/core/account-pool/src/index.ts
@@ -199,7 +199,7 @@ export class AccountPoolService {
         try {
             await DB.Account.updateAccountStatus(id, 'active')
 
-            for (const [platform, accounts] of this.accountCache.entries()) {
+            for (const accounts of this.accountCache.values()) {
                 const account = accounts.find((acc) => acc.id === id)
                 if (account) {
                     account.status = 'active'
@@ -214,14 +214,32 @@ export class AccountPoolService {
         }
     }
 
-    async markAccountAsInactive(id: number): Promise<void> {
+    async markAccountAsInactive(
+        id: number,
+        failureCount?: number,
+        lastFailureAt?: Date,
+        banUntil?: Date | null,
+    ): Promise<void> {
         try {
-            await DB.Account.updateAccountStatus(id, 'inactive')
+            if (failureCount !== undefined && lastFailureAt !== undefined) {
+                await DB.Account.updateAccountFailureInfo(id, failureCount, lastFailureAt, 'inactive', banUntil)
+            } else {
+                await DB.Account.updateAccountStatus(id, 'inactive')
+            }
 
-            for (const [platform, accounts] of this.accountCache.entries()) {
+            for (const accounts of this.accountCache.values()) {
                 const account = accounts.find((acc) => acc.id === id)
                 if (account) {
                     account.status = 'inactive'
+                    if (failureCount !== undefined) {
+                        account.failure_count = failureCount
+                    }
+                    if (lastFailureAt !== undefined) {
+                        account.last_failure_at = lastFailureAt
+                    }
+                    if (banUntil !== undefined) {
+                        account.ban_until = banUntil
+                    }
                     log.warn(`Account (id: ${id}) marked as inactive in cache`)
                     break
                 }
@@ -236,7 +254,7 @@ export class AccountPoolService {
         try {
             await DB.Account.updateAccountStatus(id, 'banned')
 
-            for (const [platform, accounts] of this.accountCache.entries()) {
+            for (const accounts of this.accountCache.values()) {
                 const account = accounts.find((acc) => acc.id === id)
                 if (account) {
                     account.status = 'banned'
@@ -272,23 +290,62 @@ export class AccountPoolService {
 
     async reportAccountFailure(id: number, banDurationMinutes: number = 30): Promise<void> {
         try {
-            await DB.Account.reportAccountFailure(id, banDurationMinutes)
+            const now = new Date()
+            const maxFailures = 3
 
-            for (const [platform, accounts] of this.accountCache.entries()) {
-                const account = accounts.find((acc) => acc.id === id)
-                if (account) {
-                    account.failure_count = (account.failure_count || 0) + 1
-
-                    if (account.failure_count >= 3) {
-                        account.status = 'inactive'
-                        account.ban_until = new Date(Date.now() + banDurationMinutes * 60 * 1000)
-                        log.warn(
-                            `Account (id: ${id}) banned until ${account.ban_until.toISOString()} after ${account.failure_count} failures`,
-                        )
-                    } else {
-                        log.warn(`Account (id: ${id}) failure count: ${account.failure_count}/3`)
-                    }
+            // Get current account info from cache first
+            let account: Account | null = null
+            for (const accounts of this.accountCache.values()) {
+                const found = accounts.find((acc) => acc.id === id)
+                if (found) {
+                    account = found
                     break
+                }
+            }
+
+            // If not in cache, get from database
+            if (!account) {
+                const dbAccount = await DB.Account.getAccountById(id)
+                if (!dbAccount) {
+                    log.error(`Account (id: ${id}) not found`)
+                    return
+                }
+                account = dbAccount as Account
+            }
+
+            const newFailureCount = (account.failure_count || 0) + 1
+
+            // Handle failure logic in account-pool
+            if (newFailureCount >= maxFailures) {
+                const banUntil = new Date(now.getTime() + banDurationMinutes * 60 * 1000)
+                await DB.Account.updateAccountFailureInfo(id, newFailureCount, now, 'inactive', banUntil)
+
+                // Update cache
+                for (const accounts of this.accountCache.values()) {
+                    const acc = accounts.find((a) => a.id === id)
+                    if (acc) {
+                        acc.failure_count = newFailureCount
+                        acc.last_failure_at = now
+                        acc.status = 'inactive'
+                        acc.ban_until = banUntil
+                        log.warn(
+                            `Account (id: ${id}) banned until ${banUntil.toISOString()} after ${newFailureCount} failures`,
+                        )
+                        break
+                    }
+                }
+            } else {
+                await DB.Account.updateAccountFailureInfo(id, newFailureCount, now)
+
+                // Update cache
+                for (const accounts of this.accountCache.values()) {
+                    const acc = accounts.find((a) => a.id === id)
+                    if (acc) {
+                        acc.failure_count = newFailureCount
+                        acc.last_failure_at = now
+                        log.warn(`Account (id: ${id}) failure count: ${newFailureCount}/${maxFailures}`)
+                        break
+                    }
                 }
             }
         } catch (error: any) {
@@ -301,7 +358,7 @@ export class AccountPoolService {
         try {
             await DB.Account.reportAccountSuccess(id)
 
-            for (const [platform, accounts] of this.accountCache.entries()) {
+            for (const accounts of this.accountCache.values()) {
                 const account = accounts.find((acc) => acc.id === id)
                 if (account) {
                     account.failure_count = 0

--- a/core/config/src/types/crawler.ts
+++ b/core/config/src/types/crawler.ts
@@ -30,14 +30,6 @@ interface CrawlerConfig extends CommonCfgConfig {
         max: number
         min: number
     }
-    /**
-     * TODO
-     *
-     * Will trigger the immediate notify to subscribed forwarders after the crawling
-     *
-     * Only works for `task_type` = `article` for now
-     */
-    immediate_notify?: boolean
     user_agent?: string
     translator?: Translator
     /**

--- a/core/db/src/operations/account.ts
+++ b/core/db/src/operations/account.ts
@@ -23,6 +23,13 @@ export interface AccountOperations {
     findAvailableAccount(platform: Platform, requestedAccountName?: string): Promise<DBAccount | undefined>
     updateAccountLastUsed(id: number): Promise<void>
     updateAccountStatus(id: number, status: AccountStatus): Promise<void>
+    updateAccountFailureInfo(
+        id: number,
+        failureCount: number,
+        lastFailureAt: Date,
+        status?: AccountStatus,
+        banUntil?: Date | null,
+    ): Promise<void>
     reportAccountFailure(id: number, banDurationMinutes?: number): Promise<void>
     reportAccountSuccess(id: number): Promise<void>
     unbanExpiredAccounts(): Promise<number>
@@ -164,6 +171,35 @@ export function createAccountOperations(adapter: SqliteAdapter | PgAdapter): Acc
             .returning()
     }
 
+    async function updateAccountFailureInfo(
+        id: number,
+        failureCount: number,
+        lastFailureAt: Date,
+        status?: AccountStatus,
+        banUntil?: Date | null,
+    ): Promise<void> {
+        const now = new Date()
+        const updates: any = {
+            failure_count: failureCount,
+            last_failure_at: lastFailureAt,
+            updated_at: now,
+        }
+
+        if (status !== undefined) {
+            updates.status = status
+        }
+
+        if (banUntil !== undefined) {
+            updates.ban_until = banUntil
+        }
+
+        await db
+            .update(accountTable as any)
+            .set(updates)
+            .where(eq((accountTable as any).id, id))
+            .returning()
+    }
+
     async function reportAccountFailure(id: number, banDurationMinutes: number = 30): Promise<void> {
         const now = new Date()
         const account = await getAccountById(id)
@@ -243,6 +279,7 @@ export function createAccountOperations(adapter: SqliteAdapter | PgAdapter): Acc
         findAvailableAccount,
         updateAccountLastUsed,
         updateAccountStatus,
+        updateAccountFailureInfo,
         reportAccountFailure,
         reportAccountSuccess,
         unbanExpiredAccounts,


### PR DESCRIPTION
## Summary

- detect rate-limit and authentication failures and persist account failure metadata
- add trace-aware crawler, sender, and account-pool logging
- recycle Puppeteer browser instances after a configurable page count and relaunch disconnected browsers
- guard account release for crawler tasks that do not use an account
- remove the unused immediate_notify crawler option

## Verification

- bun --filter @idol-bbq-utils/crawler-service build
- bun --filter @idol-bbq-utils/scheduler-service build
- git diff --check