### PR TITLE
fix(ci): allow attestation metadata writes

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -44,6 +44,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
       id-token: write
       # 
     steps:


### PR DESCRIPTION
## Summary

- grant the permission required by the updated provenance action to persist artifact metadata
- remove the warning observed during the first successful distributed-image publication

## Validation

- workflow YAML parses successfully
- the preceding main run built and pushed both images; this permission addresses its explicit `artifact-metadata:write` annotation